### PR TITLE
Use all-lowercase for the "deepin" distro brand

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -16,7 +16,7 @@ libLoL (LoongArch on LoongArch) 是一款用于提供旧世界 ABI 兼容性的�
 {{< cards >}}
 {{< card link="/docs/usage/#aosc-os" title="AOSC OS" icon="aosc-os-no-padding" >}}
 {{< card link="/docs/usage/#debian" title="Debian" icon="debian" >}}
-{{< card link="/docs/usage/#deepin" title="Deepin" icon="deepin" >}}
+{{< card link="/docs/usage/#deepin" title="deepin" icon="deepin" >}}
 {{< card link="/docs/usage/#gentoo" title="Gentoo" icon="gentoo" >}}
 {{< card link="/docs/usage/#loong-arch-linux" title="Loong Arch Linux" icon="archlinux" >}}
 {{< card link="/docs/usage/#slackwareloong" title="Slackwareloong" icon="slackware" >}}

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -52,9 +52,9 @@ sudo apt install ./liblol_0.1.5-1_loong64.deb
 
 其中带有 `local` 字样的目录可供用户自助放置一些库文件，以便绕过个别应用所存在的问题。
 
-### Deepin
+### deepin
 
-Deepin 在主软件仓库提供 libLoL，使用如下命令安装即可使用：
+deepin 在主软件仓库提供 libLoL，使用如下命令安装即可使用：
 
 ```
 sudo apt install liblol liblol-dkms


### PR DESCRIPTION
According to deepin's [品牌专有名词指导方针], the name "deepin" shall always stay lowercase if it is used to refer to the distribution as a whole.

[品牌专有名词指导方针]: https://wiki.deepin.org/zh/03_技术规范/01_文档规范/品牌专有名词指导方针