### PR TITLE
Update usage.md

### DIFF
--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -35,10 +35,10 @@ oma install liblol
 sudo apt install ./liblol-dkms_0.1.1_loong64.deb
 ```
 
-安装完成后，在[此页面](https://github.com/AOSC-Dev/liblol/releases)下载最新版本的 libLoL 运行时包 [liblol_0.1.6-1_loong64.deb](https://github.com/AOSC-Dev/liblol/releases/download/debian%2Fv0.1.6-1/liblol_0.1.6-1_loong64.deb)，随后执行如下命令安装：
+安装完成后，在[此页面](https://github.com/AOSC-Dev/liblol/releases)下载最新版本的 libLoL 运行时包 [liblol_0.1.9-1_loong64.deb](https://github.com/AOSC-Dev/liblol/releases/download/debian%2Fv0.1.9-1/liblol_0.1.9-1_loong64.deb)，随后执行如下命令安装：
 
 ```
-sudo apt install ./liblol_0.1.6-1_loong64.deb
+sudo apt install ./liblol_0.1.9-1_loong64.deb
 ```
 
 由于不同发行版的目录布局各异，不同发行版上的 libLoL 库搜索路径之间也存在不同。Debian 上 libLoL 的库搜索路径如下：


### PR DESCRIPTION
liblol has been updated to 0.1.9 to compat glibc 2.41
根据https://mp.weixin.qq.com/s/P-dU9YSF5ng4yVkyMtY6ew，更新liblol网站的liblol版本